### PR TITLE
:wrench: Update Easy Install to fix path issues

### DIFF
--- a/Easy_Install.sh
+++ b/Easy_Install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 cd ~
 echo "Downloading needed files started"
-git clone https://github.com/saint-13/Linux_Dynamic_Wallpapers.git
+git clone https://github.com/saint-13/Linux_Dynamic_Wallpapers.git  
+cd Linux_Dynamic_Wallpapers
 echo "Files downloaded"
 
 if [[ -d /usr/share/backgrounds/Dynamic_Wallpapers ]]


### PR DESCRIPTION
The Easy Install script starts by cloning this repo and executes commands which are path dependent (e.g. `sudo cp -r ./Dynamic_Wallpapers/ /usr/share/backgrounds/`). These path dependent commands fail, because we do not change into the cloned directory after cloning.

An alternative approach might be to make the script path independent.

Tested on Ubuntu 5.10.0-1057.61-oem 5.10.83
