### PR TITLE
Adding some fixes for the install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,8 @@ then
 fi
 
 echo "Installing wallpapers..."
-mkdir -p /usr/share/backgrounds/Dynamic_Wallpapers
-mkdir -p /usr/share/gnome-background-properties/ 
-sudo ln -s $(pwd)/Dynamic_Wallpapers /usr/share/backgrounds/Dynamic_Wallpapers
-sudo ln -s $(pwd)/xml/* /usr/share/gnome-background-properties/
+sudo mkdir -p /usr/share/backgrounds/Dynamic_Wallpapers
+sudo mkdir -p /usr/share/gnome-background-properties/ 
+sudo ln -sf $(pwd)/Dynamic_Wallpapers /usr/share/backgrounds/Dynamic_Wallpapers
+sudo ln -sf $(pwd)/xml/* /usr/share/gnome-background-properties/
 echo "Wallpapers has been installed. Enjoy setting them as your desktop background!"

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ then
 fi
 
 echo "Installing wallpapers..."
-sudo mkdir -p /usr/share/backgrounds/Dynamic_Wallpapers
+sudo mkdir -p /usr/share/backgrounds/
 sudo mkdir -p /usr/share/gnome-background-properties/ 
 sudo ln -sf $(pwd)/Dynamic_Wallpapers /usr/share/backgrounds/Dynamic_Wallpapers
 sudo ln -sf $(pwd)/xml/* /usr/share/gnome-background-properties/

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,8 @@ then
 fi
 
 echo "Installing wallpapers..."
+mkdir -p /usr/share/backgrounds/Dynamic_Wallpapers
+mkdir -p /usr/share/gnome-background-properties/ 
 sudo ln -s $(pwd)/Dynamic_Wallpapers /usr/share/backgrounds/Dynamic_Wallpapers
 sudo ln -s $(pwd)/xml/* /usr/share/gnome-background-properties/
 echo "Wallpapers has been installed. Enjoy setting them as your desktop background!"


### PR DESCRIPTION
First commit fixes a functionality error. If the directories do not exist when running the script then the wallpapers are not linked to the right destination.

The second fixes an aesthetic problem, when running the script at a later date you'll get an error about the file already existing at the destination. Excerpt below:

```
ln: failed to create symbolic link '/usr/share/gnome-background-properties/TheBeach.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/TheDesert.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/TheLake.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/TokyoStreet.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/Truchet.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/UbuntuMinimal.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/Viragegy.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/Viragharom.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/Viragnegy.xml': File exists
ln: failed to create symbolic link '/usr/share/gnome-background-properties/WaterHill.xml': File exists
``` 
