### PR TITLE
Added Gnome 42+ Light/Dark instructions + Table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 	<a href="https://www.gnome-look.org/p/1499429"><img src=https://img.shields.io/badge/Rank%20on%20Gnome--look.org-First-%23FFD700%20?logo=gnome&logoColor=lightgrey&labelColor=303030 /></a>
 </p>
 
+ * [🎨 Preview](#-preview)
+ * [:gear: Installation](#gear-installation)
+ * [:gear: Light/Dark Mode Installation (Gnome 42+)](#gear-lightdark-mode-installation-gnome-42)
+ * [:paintbrush: Wallpapers Authors](#paintbrus-wallpapers-authors)
+ * [:octocat: I want to contribute!](#octocat-i-want-to-contribute)
+ * [:memo: To do list](#memo-to-do-list)
+ * [:revolving_hearts: Contributors](#revolving_hearts-contributors)
+ * [:radioactive: Notice](#radioactive-notice)
+ * [🔗 External links](#-external-links)
+
 ## 🎨 Preview
 ### Abstract
 | 			   	              										        			| 			     															     | 															   	  			     | 																	         |
@@ -115,7 +125,7 @@
 | 	   	              															        | 		     																     | 												 					     	             | 															     			 |
 -->
 
-## :gear: Installation:
+## :gear: Installation
 #### RECOMMEND: Easy, Time and data saving :star:
 1. Open Terminal
 2. Run the following command:
@@ -164,7 +174,7 @@
 
 4. That's it. Enjoy! :tada:
 
-## :gear: Light/Dark Mode Installation (Gnome 42+):
+## :gear: Light/Dark Mode Installation (Gnome 42+)
 
 > :warning: **Requires Gnome 42 or newer**
 
@@ -181,7 +191,7 @@ The command above will install *all* the wallpapers in the directory
 configuration file into
 */usr/share/gnome-background-properties/LinuxLightDarkWallpapers.xml*.
 
-## :paintbrush: Wallpapers Authors:
+## :paintbrush: Wallpapers Authors
 - Apple Inc.
 - Elementary Os
 - Ubuntu

--- a/README.md
+++ b/README.md
@@ -164,6 +164,23 @@
 
 4. That's it. Enjoy! :tada:
 
+## :gear: Light/Dark Mode Installation (Gnome 42+):
+
+> :warning: **Requires Gnome 42 or newer**
+
+If, instead of the varying over-time dynamic wallpapers, you'd like to install them so that they change based on the active Gnome (light/dark) mode. Use the provided python script install_gnome_42_light_dark.py.
+
+```console
+sudo python3 install_gnome_42_light_dark.py LinuxLightDarkWallpapers \
+    Dynamic_Wallpapers \
+    /usr/share
+```
+
+The command above will install *all* the wallpapers in the directory 
+*/usr/share/backgrounds/LinuxLightDarkWallpapers*, and the the wallpapers'
+configuration file into
+*/usr/share/gnome-background-properties/LinuxLightDarkWallpapers.xml*.
+
 ## :paintbrush: Wallpapers Authors:
 - Apple Inc.
 - Elementary Os


### PR DESCRIPTION
In Gnome 42+ some people (me included) may prefer installing the wallpapers such that they change based on Gnome's mode. But there are no instructions on how to do so.

Also the documentations is quite long (mostly due to the preview section) I took the liberty of adding a table of contents. But I can remove it and create a PR with only the Gnome 42 section.

P.D: Thanks for this cool wallpapers project :)