### PR TITLE
:beetle: Fix permissions from 700 to 755

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,5 +9,6 @@ echo "Installing wallpapers..."
 sudo mkdir -p /usr/share/backgrounds/
 sudo mkdir -p /usr/share/gnome-background-properties/ 
 sudo cp -r $(pwd)/Dynamic_Wallpapers /usr/share/backgrounds/Dynamic_Wallpapers
+sudo chmod -R 755 /usr/share/backgrounds/Dynamic_Wallpapers
 sudo cp $(pwd)/xml/* /usr/share/gnome-background-properties/
 echo "Wallpapers has been installed. Enjoy setting them as your desktop background!"


### PR DESCRIPTION
The settings app cannot access the wallpaper and gives a blank image. This should fix it.

The issue occurs when I downloaded the project as a zip instead of using git or _Install.sh and then running sudo ./install.sh