### PR TITLE
Fixed the command on README so now it works + clean up the remaining empty git directory

### DIFF
--- a/Interactive_Install.sh
+++ b/Interactive_Install.sh
@@ -3,6 +3,9 @@ WALPAPER_DEST="/usr/share/backgrounds/Dynamic_Wallpapers"
 XML_DEST="/usr/share/gnome-background-properties/"
 GIT_URL="https://github.com/saint-13/Linux_Dynamic_Wallpapers.git/"
 
+# clean the remaining git directory on pwd on exit
+trap 'rm -rf "$PWD/Linux_Dynamic_Wallpapers"' EXIT
+
 # Clone .git folder -> Lightweigh checkout
 git clone --filter=blob:none --no-checkout "$GIT_URL"
 
@@ -75,5 +78,6 @@ while IFS= read -r to_install; do
 done <<< "$user_selection"
 
 echo
+
 echo "Success !"
 echo "💜 Please support on https://github.com/saint-13/Linux_Dynamic_Wallpapers"

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@
 1. Open Terminal
 2. Run the following command:
     ```
-    curl -s "https://raw.githubusercontent.com/saint-13/Linux_Dynamic_Wallpapers/main/Interactive_Install.sh" | sudo bash
+    curl -s "https://raw.githubusercontent.com/saint-13/Linux_Dynamic_Wallpapers/main/Interactive_Install.sh" > install.sh
+    sudo bash install.sh
     ```
 3. Select the walpapers you wish to install from the list
 4. Script will download and install only selected ones


### PR DESCRIPTION
Changing the command on the readme (see #58).

I also added `trap 'rm -rf "$PWD/Linux_Dynamic_Wallpapers"' EXIT` on the script so it removes the empty git directory that the script creates on pwd on exit.