### PR TITLE
Use a shallow clone to reduce the download size

### DIFF
--- a/Easy_Install.sh
+++ b/Easy_Install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd ~
 echo "Downloading needed files started"
-git clone https://github.com/saint-13/Linux_Dynamic_Wallpapers.git  
+git clone https://github.com/saint-13/Linux_Dynamic_Wallpapers.git --depth=1
 cd Linux_Dynamic_Wallpapers
 echo "Files downloaded"
 


### PR DESCRIPTION
Create a shallow clone with a history truncated to the specified number of revisions.